### PR TITLE
Privacy and Images for Personal Boards

### DIFF
--- a/web_app/src/PersonalBoards.js
+++ b/web_app/src/PersonalBoards.js
@@ -3,7 +3,7 @@ import { Button, TextField, FormControlLabel, IconButton, Grid } from '@material
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
 import { Menu, ListItemIcon } from '@material-ui/core';
 import { Card, CardHeader, CardActions, CardMedia } from '@material-ui/core'
-import { Lock, LockOpen, Delete, PlayArrow, MoreVert } from '@material-ui/icons';
+import { Lock, LockOpen, Delete, PlayArrow, MoreVert, Image } from '@material-ui/icons';
 import firebase from "firebase";
 import clsx from 'clsx';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
@@ -41,6 +41,7 @@ class PersonalBoards extends React.Component {
 
             anchorEl: null,
             selectedBoardID: " ",
+            isImageChangeDialogOpen: false,
         }
     }
 
@@ -152,7 +153,8 @@ class PersonalBoards extends React.Component {
         this.setState({
             isDialogOpen: false,
             boardName: '',
-            isPrivate: false
+            isPrivate: false,
+            boardImageURL: "",
         });
     }
 
@@ -248,6 +250,41 @@ class PersonalBoards extends React.Component {
         this.setState({
             anchorEl: null,
         });
+    }
+
+    handleImageChangeDialogOpen = () => {
+        this.setState({
+            isImageChangeDialogOpen: true,
+        });
+        this.handleMenuClose(); // will close the menu when Change Image selected
+    }
+
+    handleImageChangeDialogClose = () => {
+        this.setState({
+            isImageChangeDialogOpen: false,
+            boardImageURL: "",
+        });
+    }
+
+    handleImageChange = async (event, doc) => {
+        event.preventDefault();
+        // get the form data out of state
+        const {boardImageURL}  = this.state;
+
+        // clear the form
+        this.setState({
+            boardImageURL: "",
+        });
+
+        await firebase.firestore()
+        .collection('personalBoards')
+        .doc(firebase.auth().currentUser.uid)
+        .collection("pboards")
+        .doc(doc)
+        .update({
+            imageURL: boardImageURL
+        });
+        this.handleImageChangeDialogClose();
     }
 
     render() {
@@ -368,7 +405,52 @@ class PersonalBoards extends React.Component {
                     </ListItemIcon>
                     <ListItemText primary="Delete"/>
                 </MenuItem>
+                <MenuItem onClick={() => this.handleImageChangeDialogOpen()} >
+                    <ListItemIcon>
+                        <Image />
+                    </ListItemIcon>
+                    <ListItemText primary="Change Image"/>
+                </MenuItem>
             </Menu>
+
+            <Dialog
+                open={this.state.isImageChangeDialogOpen}
+                onClose={this.handleImageChangeDialogClose}
+            >
+                <DialogTitle>
+                Change the Image of the "{this.state.selectedBoardName}" Personal Board.
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Please enter the image URL.
+                    </DialogContentText>
+
+                    <form
+                        onSubmit={(e) => this.handleImageChange(e, this.state.selectedBoardID)}
+                        style={{ paddingLeft: 25, flexDirection: 'column', display: 'flex', paddingRight: 25, justifyContent: 'space-around', height: 250 }}
+                    >
+                        <TextField
+                            id="outlined-basic"
+                            label="Image URL"
+                            placeholder="Example: https://reactjs.org/logo-og.png"
+                            value={this.state.boardImageURL}
+                            name="boardImageURL"
+                            onChange={this.handleInputChange}
+                            type="text"
+                            color="secondary"
+                            required
+                        />
+                        <Button variant="contained" color="secondary" type="submit">
+                            Save Change
+                        </Button>
+                    </form>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={this.handleImageChangeDialogClose} color="secondary">
+                        Cancel
+                    </Button>
+                </DialogActions>
+            </Dialog>        
 
             <Grid
               container

--- a/web_app/src/PersonalBoards.js
+++ b/web_app/src/PersonalBoards.js
@@ -3,7 +3,7 @@ import { Button, TextField, FormControlLabel, IconButton, Grid } from '@material
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
 import { Menu, ListItemIcon } from '@material-ui/core';
 import { Card, CardHeader, CardActions, CardMedia } from '@material-ui/core'
-import { Lock, LockOpen, Delete, PlayArrow, MoreVert, Image } from '@material-ui/icons';
+import { Lock, LockOpen, Delete, PlayArrow, MoreVert, Image, RemoveCircle } from '@material-ui/icons';
 import firebase from "firebase";
 import clsx from 'clsx';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
@@ -42,6 +42,7 @@ class PersonalBoards extends React.Component {
             anchorEl: null,
             selectedBoardID: " ",
             isImageChangeDialogOpen: false,
+            isDeleteImageDialogOpen: false,
         }
     }
 
@@ -287,6 +288,31 @@ class PersonalBoards extends React.Component {
         this.handleImageChangeDialogClose();
     }
 
+    handleDeleteImageDialogOpen = () => {
+        this.setState({
+            isDeleteImageDialogOpen: true,
+        });
+        this.handleMenuClose(); // will close the menu when Remove Image selected
+    }
+
+    handleDeleteImageDialogClose = () => {
+        this.setState({
+            isDeleteImageDialogOpen: false,
+        });
+    }
+
+    handleDeleteImage = async (doc) => {
+        await firebase.firestore()
+        .collection('personalBoards')
+        .doc(firebase.auth().currentUser.uid)
+        .collection("pboards")
+        .doc(doc)
+        .update({
+            imageURL: ""
+        });
+        this.handleDeleteImageDialogClose();
+    }
+
     render() {
         const personalBoards = this.state.personalBoards;
 
@@ -411,6 +437,12 @@ class PersonalBoards extends React.Component {
                     </ListItemIcon>
                     <ListItemText primary="Change Image"/>
                 </MenuItem>
+                <MenuItem onClick={() => this.handleDeleteImageDialogOpen()} >
+                    <ListItemIcon>
+                        <RemoveCircle />
+                    </ListItemIcon>
+                    <ListItemText primary="Remove Image"/>
+                </MenuItem>
             </Menu>
 
             <Dialog
@@ -451,6 +483,24 @@ class PersonalBoards extends React.Component {
                     </Button>
                 </DialogActions>
             </Dialog>        
+            
+            <Dialog
+                open={this.state.isDeleteImageDialogOpen}
+                onClose={this.handleDeleteImageDialogClose}
+            >
+                <DialogTitle>
+                    Are you sure you want to remove the image for the "{this.state.selectedBoardName}" Personal Board?
+                </DialogTitle>
+                <DialogContent>
+                    <DialogContentText>
+                        Removing the image will set the image to the FETCH logo.
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={this.handleDeleteImageDialogClose}>No</Button>
+                    <Button onClick={() => this.handleDeleteImage(this.state.selectedBoardID)} color="secondary">Yes</Button>
+                </DialogActions>
+            </Dialog>
 
             <Grid
               container

--- a/web_app/src/PersonalBoards.js
+++ b/web_app/src/PersonalBoards.js
@@ -191,6 +191,17 @@ class PersonalBoards extends React.Component {
 
     }
 
+    handleChangePrivate = async (doc, isPrivate) => {
+        await firebase.firestore()
+        .collection('personalBoards')
+        .doc(firebase.auth().currentUser.uid)
+        .collection("pboards")
+        .doc(doc)
+        .update({
+            isPrivate: !isPrivate,
+        });
+    }
+
     render() {
         const personalBoards = this.state.personalBoards;
 
@@ -285,7 +296,15 @@ class PersonalBoards extends React.Component {
                   <Card style={{width: 250, height: 300, margin: '0.5rem'}} >
                       <CardHeader
                       title={board.boardName}
-                      subheader={board.isPrivate ? <Lock/> : <LockOpen/> }
+                      subheader={board.isPrivate ? 
+                        <IconButton onClick={() => this.handleChangePrivate(board.boardID, true)}>
+                            <Lock/>
+                        </IconButton> 
+                        : 
+                        <IconButton onClick={() => this.handleChangePrivate(board.boardID, false)}>
+                            <LockOpen/>
+                        </IconButton> 
+                      }
                       action={
                         <IconButton onClick={() => this.handleDeleteDialogOpen(board.boardID)}>
                             <Delete />

--- a/web_app/src/PersonalBoards.js
+++ b/web_app/src/PersonalBoards.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import { Button, TextField, FormControlLabel, IconButton, Grid } from '@material-ui/core';
 import { Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle } from '@material-ui/core';
+import { Menu, ListItemIcon } from '@material-ui/core';
 import { Card, CardHeader, CardActions, CardMedia } from '@material-ui/core'
-import { Lock, LockOpen, Delete, PlayArrow } from '@material-ui/icons';
+import { Lock, LockOpen, Delete, PlayArrow, MoreVert } from '@material-ui/icons';
 import firebase from "firebase";
 import clsx from 'clsx';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
@@ -37,6 +38,9 @@ class PersonalBoards extends React.Component {
             selectedBoardPrivate: " ",
             isSelectedBoardPrivate: false,
             selectedBoardName: "",
+
+            anchorEl: null,
+            selectedBoardID: " ",
         }
     }
 
@@ -166,6 +170,7 @@ class PersonalBoards extends React.Component {
             selectedBoardDelete: doc,
             selectedBoardName: docName
         });
+        this.handleMenuClose(); // will close the menu when delete selected
     }
 
     handleDeleteDialogClose = () => {
@@ -229,6 +234,20 @@ class PersonalBoards extends React.Component {
         });
         this.handlePrivateDialogClose();
 
+    }
+
+    handleMenuOpen = (event, doc, docName) => {
+        this.setState({
+            anchorEl: event.currentTarget,
+            selectedBoardID: doc,
+            selectedBoardName: docName,
+        });
+    }
+    
+    handleMenuClose = () => {
+        this.setState({
+            anchorEl: null,
+        });
     }
 
     render() {
@@ -336,7 +355,20 @@ class PersonalBoards extends React.Component {
                 </DialogActions>
 
             </Dialog>
-
+            <Menu
+              id="customized-menu"
+              anchorEl={this.state.anchorEl}
+              keepMounted
+              open={Boolean(this.state.anchorEl)}
+              onClose={this.handleMenuClose}
+            >
+                <MenuItem onClick={() => this.handleDeleteDialogOpen(this.state.selectedBoardID, this.state.selectedBoardName)} >
+                    <ListItemIcon>
+                        <Delete />
+                    </ListItemIcon>
+                    <ListItemText primary="Delete"/>
+                </MenuItem>
+            </Menu>
 
             <Grid
               container
@@ -363,8 +395,8 @@ class PersonalBoards extends React.Component {
                         </IconButton> 
                       }
                       action={
-                        <IconButton onClick={() => this.handleDeleteDialogOpen(board.boardID, board.boardName)}>
-                            <Delete />
+                        <IconButton onClick={(e) => this.handleMenuOpen(e, board.boardID, board.boardName)}>
+                            <MoreVert />
                         </IconButton>
                         }
                       >

--- a/web_app/src/PersonalBoards.js
+++ b/web_app/src/PersonalBoards.js
@@ -27,6 +27,7 @@ class PersonalBoards extends React.Component {
         this.state = {
             boardName: '',
             isPrivate: false,
+            boardImageURL: "",
             isDialogOpen: false,
             isAddOpen: false,
             personalBoards: [],
@@ -53,6 +54,7 @@ class PersonalBoards extends React.Component {
                 let newPersonalBoard = {
                     boardName: doc.data().boardName,
                     isPrivate: doc.data().isPrivate,
+                    imageURL: doc.data().imageURL || "",
                     boardID: doc.id,
                 }
                 personalBoards.push(newPersonalBoard);
@@ -89,12 +91,13 @@ class PersonalBoards extends React.Component {
         event.preventDefault();
 
         // get the form data out of state
-        const { boardName, isPrivate } = this.state;
+        const { boardName, isPrivate, boardImageURL } = this.state;
 
         // clear the form
         this.setState({
             boardName: '',
             isPrivate: false,
+            boardImageURL: "",
         });
 
         console.log("Board Name: " + boardName)
@@ -112,6 +115,7 @@ class PersonalBoards extends React.Component {
             followers: [],
             queue: [],
             timestamp: Date.now(),
+            imageURL: boardImageURL,
         }).then(function(docRef) {
             console.log("success! docID", docRef.id);
         })
@@ -177,7 +181,7 @@ class PersonalBoards extends React.Component {
 
         await firebase.firestore()
         .collection("personalBoards")
-        .doc(firebase.auth().currentUser.uid) // hardcoded userid
+        .doc(firebase.auth().currentUser.uid)
         .collection("pboards")
         .doc(doc)
         .delete()
@@ -271,6 +275,16 @@ class PersonalBoards extends React.Component {
                             required
                             color="secondary"
                         />
+                        <TextField
+                            id="outlined-basic"
+                            label="Image URL"
+                            placeholder="Example: https://reactjs.org/logo-og.png"
+                            value={this.state.boardImageURL}
+                            name="boardImageURL"
+                            onChange={this.handleInputChange}
+                            type="text"
+                            color="secondary"
+                        />
                         <FormControlLabel
                             label="Private"
                             control={
@@ -356,7 +370,11 @@ class PersonalBoards extends React.Component {
                       >
                       </CardHeader>
                       <CardMedia style={{height: 0, paddingTop: '50%'}}
-                        image={logo}
+                        image={(board.imageURL === "") ?
+                            logo
+                            :
+                            board.imageURL
+                        }
                         title="FETCH"
                       />
                     <CardActions>

--- a/web_app/src/PersonalBoards.js
+++ b/web_app/src/PersonalBoards.js
@@ -31,7 +31,11 @@ class PersonalBoards extends React.Component {
             isAddOpen: false,
             personalBoards: [],
             isDeleteDialogOpen: false,
-            selectedBoardDelete: "",
+            selectedBoardDelete: " ",
+            isPrivateDialogOpen: false,
+            selectedBoardPrivate: " ",
+            isSelectedBoardPrivate: false,
+            selectedBoardName: "",
         }
     }
 
@@ -151,11 +155,12 @@ class PersonalBoards extends React.Component {
         });
     }
 
-    handleDeleteDialogOpen = (doc) => {
+    handleDeleteDialogOpen = (doc, docName) => {
         console.log("DOC ID: ", doc)
         this.setState({
             isDeleteDialogOpen: true,
             selectedBoardDelete: doc,
+            selectedBoardName: docName
         });
     }
 
@@ -163,7 +168,7 @@ class PersonalBoards extends React.Component {
         // closes the dialog for delete
         this.setState({
             isDeleteDialogOpen: false,
-            selectedBoardDelete: "",
+            selectedBoardDelete: " ",
         });
     }
 
@@ -186,9 +191,27 @@ class PersonalBoards extends React.Component {
         // will close the dialog after submission
         this.setState({
             isDeleteDialogOpen: false,
-            selectedBoardDelete: "",
+            selectedBoardDelete: " ",
         });
 
+    }
+
+    handlePrivateDialogOpen = (doc, docName, isPrivate) => {
+        console.log("DOC ID: ", doc)
+        this.setState({
+            isPrivateDialogOpen: true,
+            selectedBoardPrivate: doc,
+            isSelectedBoardPrivate: isPrivate,
+            selectedBoardName: docName,
+        });
+    }
+
+    handlePrivateDialogClose = () => {
+        // closes the dialog for delete
+        this.setState({
+            isPrivateDialogOpen: false,
+            selectedBoardPrivate: " ",
+        });
     }
 
     handleChangePrivate = async (doc, isPrivate) => {
@@ -200,6 +223,8 @@ class PersonalBoards extends React.Component {
         .update({
             isPrivate: !isPrivate,
         });
+        this.handlePrivateDialogClose();
+
     }
 
     render() {
@@ -272,7 +297,7 @@ class PersonalBoards extends React.Component {
                 onClose={this.handleDeleteDialogClose}
             >
                 <DialogTitle>
-                    Are you sure you want to delete this Personal Board?
+                    Are you sure you want to DELETE the "{this.state.selectedBoardName}" Personal Board?
                 </DialogTitle>
                 <DialogActions>
                     <Button onClick={this.handleDeleteDialogClose}>No</Button>
@@ -280,6 +305,24 @@ class PersonalBoards extends React.Component {
                 </DialogActions>
 
             </Dialog>
+            <Dialog
+                open={this.state.isPrivateDialogOpen}
+                onClose={this.handlePrivateDialogClose}
+            >
+                <DialogTitle>
+                    {this.state.isSelectedBoardPrivate ? 
+                    "Are you sure you want to make the \"" + this.state.selectedBoardName + "\" Personal Board NOT private?" 
+                    : 
+                    "Are you sure you want to make the \"" + this.state.selectedBoardName + "\" Personal Board private?"
+                    }
+                </DialogTitle>
+                <DialogActions>
+                    <Button onClick={this.handlePrivateDialogClose}>No</Button>
+                    <Button onClick={() => this.handleChangePrivate(this.state.selectedBoardPrivate, this.state.isSelectedBoardPrivate)} color="secondary">Yes</Button>
+                </DialogActions>
+
+            </Dialog>
+
 
             <Grid
               container
@@ -297,16 +340,16 @@ class PersonalBoards extends React.Component {
                       <CardHeader
                       title={board.boardName}
                       subheader={board.isPrivate ? 
-                        <IconButton onClick={() => this.handleChangePrivate(board.boardID, true)}>
+                        <IconButton onClick={() => this.handlePrivateDialogOpen(board.boardID, board.boardName, true)}>
                             <Lock/>
                         </IconButton> 
                         : 
-                        <IconButton onClick={() => this.handleChangePrivate(board.boardID, false)}>
+                        <IconButton onClick={() => this.handlePrivateDialogOpen(board.boardID, board.boardName, false)}>
                             <LockOpen/>
                         </IconButton> 
                       }
                       action={
-                        <IconButton onClick={() => this.handleDeleteDialogOpen(board.boardID)}>
+                        <IconButton onClick={() => this.handleDeleteDialogOpen(board.boardID, board.boardName)}>
                             <Delete />
                         </IconButton>
                         }


### PR DESCRIPTION
- Can change private setting for personal boards with toggle icon button
- Dialog appears to make sure the user wants to change the setting
- Changes to delete dialog to make board name appear in the dialog
- Can now add image url when creating personal board
- Adds settings menu for each personal board
- Inside settings menu: delete, change image, remove image
- Can change or remove image from personal board ("removing" sets it to default FETCH logo)